### PR TITLE
Add per-token support to disable panning

### DIFF
--- a/apps/tokenbar.js
+++ b/apps/tokenbar.js
@@ -305,6 +305,14 @@ export class TokenBar extends Application {
         if (tkn.inspiration != (tkn.token.actor.data?.data?.attributes?.inspiration && setting('show-inspiration')))
             diff.inspiration = (tkn.token.actor.data?.data?.attributes?.inspiration && setting('show-inspiration'));
 
+        if (game.settings.get("monks-tokenbar", "show-disable-panning-option")) {
+          if (tkn.nopanning != tkn.token.document.getFlag('monks-tokenbar', 'nopanning')) {
+            diff.nopanning = tkn.token.document.getFlag('monks-tokenbar', 'nopanning');
+          }
+        } else {
+          diff.nopanning = false;
+        }
+
         if (Object.keys(diff).length > 0) {
             //log('preUpdateTokenBarToken', tkn, diff);
             mergeObject(tkn, diff);
@@ -474,6 +482,15 @@ export class TokenBar extends Application {
                 }
             },
             {
+                name: "MonksTokenBar.DisablePanning",
+                icon: '<i class="fas fa-user-slash"></i>',
+                condition: game.settings.get("monks-tokenbar", "show-disable-panning-option"),
+                callback: li => {
+                    let entry = this.getEntry(li[0].dataset.tokenId);
+                    MonksTokenBar.changeTokenPanning(entry.token);
+                }
+            },
+            {
                 name: "MonksTokenBar.TargetToken",
                 icon: '<i class="fas fa-bullseye"></i>',
                 condition: game.user.isGM,
@@ -524,6 +541,12 @@ export class TokenBar extends Application {
                 $('i[data-movement="' + movement + '"]', html).parent().addClass('selected');
             }
 
+            //Highlight if nopanning option is selected
+            let nopanning = entry?.token.document.getFlag("monks-tokenbar", "nopanning");
+            if (nopanning) {
+                $('i[class="fas fa-user-slash fa-fw"]', html).parent().addClass('selected');
+            }
+
             return result;
         };
     }
@@ -571,6 +594,10 @@ export class TokenBar extends Application {
 
         log('Center on token', entry, entry.token);
         entry?.token?.control({ releaseOthers: true });
+
+        const nopanning = entry?.token.document.getFlag("monks-tokenbar", "nopanning");
+        if (nopanning) return true;
+
         return canvas.animatePan({ x: entry?.token?.x, y: entry?.token?.y });
     }
 

--- a/css/tokenbar.css
+++ b/css/tokenbar.css
@@ -325,6 +325,25 @@ body #tokenbar-window:first-child{
 #tokenbar .token .inspiration-icon[inspiration="true"] {
     display:inline-block;
 }
+
+#tokenbar .token .panning-icon {
+    position: absolute;
+    width: 20px;
+    height: 20px;
+    bottom: 0px;
+    left: 0px;
+    color: #ffc163;
+    filter: drop-shadow( 0 0 5px black);
+    background: rgba(0, 0, 0, 0.5);
+    text-align: center;
+    line-height: 22px;
+    display:none;
+    font-size: 10px;
+}
+
+#tokenbar .token .panning-icon[nopanning="true"] {
+    display:inline-block;
+}
 /*-----------------------------Dialog Styles-------------------------------------*/
 .monks-tokenbar .dialog-buttons {
     flex: 0 0 32px;

--- a/lang/en.json
+++ b/lang/en.json
@@ -3,6 +3,7 @@
 	"MonksTokenBar.EditToken": "Edit Token",
 	"MonksTokenBar.TargetToken": "Target Token",
 	"MonksTokenBar.PrivateMessage": "Private Message",
+  "MonksTokenBar.DisablePanning": "Disable Panning",
 
 	"MonksTokenBar.easy": "Easy",
 	"MonksTokenBar.average": "Average",
@@ -98,6 +99,8 @@
 	"MonksTokenBar.delete-after-grab.hint": "Delete the message after grabbing a players message roll for a requested roll.",
 	"MonksTokenBar.show-lootable-menu.name": "Show Lootable Menu",
 	"MonksTokenBar.show-lootable-menu.hint": "Show lootable button on the token menu",
+	"MonksTokenBar.show-disable-panning-option.name": "Show Disable Panning Option",
+	"MonksTokenBar.show-disable-panning-option.hint": "Show a disable panning option in the token context menu",
 	"MonksTokenBar.request-roll-sound.name": "Request Roll Sound",
 	"MonksTokenBar.request-roll-sound.hint": "Play a sound when requesting a roll",
 	"MonksTokenBar.send-levelup-whisper.name": "Whisper player on levelup",

--- a/monks-tokenbar.js
+++ b/monks-tokenbar.js
@@ -397,6 +397,20 @@ export class MonksTokenBar {
         //    MonksTokenBar.tokenbar.render(true);
     }
 
+    static async changeTokenPanning(tokens) {
+        if (tokens == undefined)
+            return;
+
+        tokens = tokens instanceof Array ? tokens : [tokens];
+
+        log('Changing token panning', tokens);
+
+        for (let token of tokens) {
+            let oldPanning = token.document.getFlag("monks-tokenbar", "nopanning");
+            await token.document.setFlag("monks-tokenbar", "nopanning", !oldPanning);
+        }
+    }
+
     static displayNotification(movement, token) {
         if (game.settings.get("monks-tokenbar", "notify-on-change")) {
             let msg = (token != undefined ? token.name + ": " : "") + i18n("MonksTokenBar.MovementChanged") + (movement == MTB_MOVEMENT_TYPE.FREE ? i18n("MonksTokenBar.FreeMovement") : (movement == MTB_MOVEMENT_TYPE.NONE ? i18n("MonksTokenBar.NoMovement") : i18n("MonksTokenBar.CombatTurn")));

--- a/settings.js
+++ b/settings.js
@@ -222,6 +222,14 @@ export const registerSettings = function () {
 		default: false,
 		type: Boolean,
 	});
+	game.settings.register(modulename, "show-disable-panning-option", {
+		name: game.i18n.localize("MonksTokenBar.show-disable-panning-option.name"),
+		hint: game.i18n.localize("MonksTokenBar.show-disable-panning-option.hint"),
+		scope: "world",
+		config: true,
+		default: false,
+		type: Boolean,
+	});
 	game.settings.register(modulename, "request-roll-sound", {
 		name: game.i18n.localize("MonksTokenBar.request-roll-sound.name"),
 		hint: game.i18n.localize("MonksTokenBar.request-roll-sound.hint"),

--- a/templates/tokenbar.html
+++ b/templates/tokenbar.html
@@ -22,6 +22,7 @@
                 <div class="token-content">
                     <div class="movement-icon" movement="{{this.movement}}"><i class="fas"></i></div>
                     <div class="inspiration-icon" inspiration="{{#if this.inspiration}}true{{/if}}" title="{{localize 'MonksTokenBar.Inspiration'}}"><i class="fas fa-crown"></i></div>
+                    <div class="panning-icon" nopanning="{{#if this.nopanning}}true{{/if}}"><i class="fas fa-user-slash"></i></div>
                     {{#if this.thumb}}
                     <img class="token-icon" src="{{this.thumb}}" />
                     {{/if}}


### PR DESCRIPTION
This context menu option allows tokens to not be panned when selected in the token bar.

This supports a special vehicle combat case where player tokens are placed on the scene out of sight and combat is conducted by the ship token they also own. In this use case, players roll from their PC sheets for the ship weapons and so being able to select (but not pan) their PC token facilitates use of Token Action HUD to roll weapons conveniently. The currently default panning isn't desired in this case, just the selection of the controlled token. It's per-token as they may want to select and pan to their ship token that they also own.

This works well with the Wildjammer module ship combat system and would probably be used by the Dark Matter team as well since they created this ship combat system.