### PR TITLE
SWADE system adjustments for 3d dice: duplicate rolls and sounds

### DIFF
--- a/apps/contestedroll.js
+++ b/apps/contestedroll.js
@@ -217,7 +217,7 @@ export class ContestedRoll {
             if (rollmode == 'gmroll' && !game.user.isGM)
                 whisper.push(game.user.id);
 
-            if (game.dice3d != undefined && roll instanceof Roll) { // && !fastForward) {
+            if (game.dice3d != undefined && roll instanceof Roll && game.system.id != 'swade') { // && !fastForward) {
                 finishroll = game.dice3d.showForRoll(roll, game.user, true, whisper, (rollmode == 'blindroll' && !game.user.isGM)).then(() => {
                     return { id: id, reveal: true, userid: game.userId };
                 });

--- a/apps/savingthrow.js
+++ b/apps/savingthrow.js
@@ -310,7 +310,7 @@ export class SavingThrow {
                 let whisper = (rollmode == 'roll' ? null : ChatMessage.getWhisperRecipients("GM").map(w => { return w.id }));
                 if (rollmode == 'gmroll' && !game.user.isGM)
                     whisper.push(game.user.id);
-                if (game.dice3d != undefined && roll instanceof Roll && roll.ignoreDice !== true) {// && !fastForward) {
+                if (game.dice3d != undefined && roll instanceof Roll && roll.ignoreDice !== true && game.system.id != 'swade') {// && !fastForward) {
                     finishroll = game.dice3d.showForRoll(roll, game.user, true, whisper, (rollmode == 'blindroll' && !game.user.isGM)).then(() => {
                         return { id: id, reveal: true, userid: game.userId };
                     });

--- a/monks-tokenbar.js
+++ b/monks-tokenbar.js
@@ -376,7 +376,7 @@ export class MonksTokenBar {
     }
 
     static getDiceSound(hasMaestroSound = false) {
-        const has3DDiceSound = game.dice3d ? game.settings.get("dice-so-nice", "settings").enabled : false;
+        const has3DDiceSound = game.dice3d ? game.modules.get("dice-so-nice").active : false;
         const playRollSounds = true; //game.settings.get("betterrolls5e", "playRollSounds")
 
         if (playRollSounds && !has3DDiceSound && !hasMaestroSound) {


### PR DESCRIPTION
Don't force dice roll, SWADE system hooks rolls already. Check for dice-so-nice correctly
* Remove explicit call for showing dice roll when system is swade. This prevents the current behavior of showing all dice in a roll twice.
* Check if dice-so-nice is enabled in the correct way so that we don't get dice sounds added by monks-tokenbar when dice-so-nice provides them itself.