### PR TITLE
Thatlonelybugbear patch 1 - Return results for ContestedRolls API calls when `silent:true` and `fastForward: true`

### DIFF
--- a/monks-tokenbar-api.js
+++ b/monks-tokenbar-api.js
@@ -64,10 +64,13 @@ export class MonksTokenBarAPI {
         if (options?.silent === true) {
             let msg = await contestedroll.request();
             if (options.fastForward === true)
-                ContestedRoll.onRollAll('all', msg, options);
+                return ContestedRoll.onRollAll('all', msg, options);
+            else
+                return msg;
         }
         else
             contestedroll.render(true);
+            return contestedroll;
     }
 
     /*


### PR DESCRIPTION
@ironmonk88  
With the changes proposed (using the SavingThrow app as an example that worked previously), I managed to get the results to log when one calls a contested roll in a macro
`results = await game.MonksTokenBar.requestContestedRoll()`

![image](https://user-images.githubusercontent.com/7237090/153053349-a895d243-3b3e-4c91-9de1-a6b031f6ce18.png)

I will test it some more when I have time, but you could use it as a reference!