### PR TITLE
Add support for PF2E degrees of success

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 .svn/
 .vs/
+.idea/
+*.iml
+*.lock

--- a/css/tokenbar.css
+++ b/css/tokenbar.css
@@ -413,7 +413,7 @@ body #tokenbar-window:first-child{
     flex: 2;
 }
 
-.monks-tokenbar .sheet .items-list .item-name h3, 
+.monks-tokenbar .sheet .items-list .item-name h3,
 .monks-tokenbar .sheet .items-list .item-name h4 {
     margin: 0;
     white-space: nowrap;
@@ -683,6 +683,10 @@ body #tokenbar-window:first-child{
     justify-content: flex-end;
 }
 
+.monks-tokenbar .sheet.actor .inventory-list .success-degrees {
+    flex: 1.4;
+}
+
 .monks-tokenbar .sheet.actor .items-list .item .item-name {
     cursor: pointer;
 }
@@ -763,11 +767,13 @@ body #tokenbar-window:first-child{
 }
 
 .monks-tokenbar li.item .dice-roll .dice-total a.result-passed.selected,
+.monks-tokenbar li.item .dice-roll .dice-total a.result-crit-passed.selected,
 .monks-tokenbar li.item .dice-roll .dice-total .dice-result.success .total{
     color: #468847;
 }
 
 .monks-tokenbar li.item .dice-roll .dice-total a.result-failed.selected,
+.monks-tokenbar li.item .dice-roll .dice-total a.result-crit-failed.selected,
 .monks-tokenbar li.item .dice-roll .dice-total .dice-result.fail .total {
     color: #b94a48;
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -180,6 +180,7 @@
 	"MonksTokenBar.Levelup": "You have enough xp to level up!",
 	"MonksTokenBar.EditStats": "Edit Stats",
 	"MonksTokenBar.Flavor": "Flavor",
+	"MonksTokenBar.UseDegreesOfSuccess": "Use degrees of success",
 	"MonksTokenBar.Convert": "Convert all Actors to be individually lootable",
 	"MonksTokenBar.Transfer": "Transfer items to single Entity",
 	"MonksTokenBar.TransferPlus": "Transfer items to single Entity and add link on Scene",

--- a/templates/savingthrow.html
+++ b/templates/savingthrow.html
@@ -8,6 +8,10 @@
                         <input type="number" step="any" id="monks-tokenbar-savingdc" placeholder="{{localize 'MonksTokenBar.SavingDCPlaceholder'}}" value="{{dc}}" />
                     </div>
                     <div class="form-group">
+                        <label>{{localize 'MonksTokenBar.UseDegreesOfSuccess'}}</label>
+                        <input type="checkbox" id="monks-tokenbar-degreesofsuccess" value="{{degrees}}" />
+                    </div>
+                    <div class="form-group">
                         <label>{{localize 'MonksTokenBar.RollMode'}}</label>
                         <select id="savingthrow-rollmode">
                             <option value="roll" selected="">{{localize 'MonksTokenBar.PublicRoll'}}</option>


### PR DESCRIPTION
Proof of concept for #111

PF2e doesn't have contested rolls, so I don't think any changes there are necessary.

I've left the ability checks intact - they work for everything except for familiars, and some GMs do use them, even if they don't explicitly exist in the rules.

I've made the degrees an option in the roll window, which is checked by default for pf2e, and unchecked for other systems. Might be useful if someone is homebrewing degrees into other systems.

Seems like all functionalities work, including saving to macro and using the macros.

I've also tested if it breaks dnd5e and it seemed fine.