### PR TITLE
Added hook to influence dice rolls

### DIFF
--- a/apps/savingthrow.js
+++ b/apps/savingthrow.js
@@ -465,11 +465,13 @@ export class SavingThrow {
                 if (update.roll) {
                     let tooltip = '';
                     if (update.roll instanceof Roll) {
+                        await this.asyncHooksCallAll('tokenBarInfluenceRoll', this, message, update);
+
                         msgtoken.roll = update.roll.toJSON();
                         msgtoken.total = update.roll.total;
                         msgtoken.reveal = update.reveal || reveal;
                         tooltip = await update.roll.getTooltip();
-
+                      
                         Hooks.callAll('tokenBarUpdateRoll', this, message, update.id, msgtoken.roll);
                     }
 
@@ -682,6 +684,17 @@ export class SavingThrow {
             e.cancelBubble = true;
             e.returnValue = false;
         }
+    }
+
+    // Note: this is a straight extract from midiQoL
+    // https://gitlab.com/tposney/midi-qol/-/blob/master/src/module/utils.ts#L3167
+    static async asyncHooksCallAll(hook, ...args) {
+        if (!Hooks._hooks.hasOwnProperty(hook)) return true;
+        const fns = new Array(...Hooks._hooks[hook]);
+        for (let fn of fns) {
+            await Hooks._call(hook, fn, args);
+        }
+        return true;
     }
 }
 


### PR DESCRIPTION
Hello,

I wanted to implement the dnd5e Lucky feat for one of my players. I'm doing this using world scripts, and for midi-qol, it was relatively smooth sailing when I started to understand how both midi & foundry's APIs works.
For your module I had a harder time, since MTB provides no hook before commiting the roll to the request. Also, I need the hook to be async-based as I'm displaying a dialog box for the player to choose to use a lucky charge or not and another to choose the final roll.

This PR is the result of what I had to modify (tested only on the 1.0.68 version) to make it works. You'll see that I had to grab an helper method from midi-qol repository. I'm not sure what's the stance regarding this in the foundry community. It might be frown upon, but I don't know how to implement it any other way (or at all for that matter!). If you know any common method that's made to be used in every module let me know. Otherwise I'll open a ticket on midi-qol's repository asking for permission to use this snippet in this PR.

Also, please let me know if you want another name for the new hook.