### PR TITLE
Fix PF2e XP rewards for non-standard party sizes

### DIFF
--- a/apps/assignxp.js
+++ b/apps/assignxp.js
@@ -32,9 +32,7 @@ export class AssignXPApp extends Application {
                 } else
                     monsters.push(combatant);
             };
-            var calcAPL = 0;
-            if (apl.count > 0)
-                calcAPL = Math.round(apl.levels / apl.count) + (apl.count < 4 ? -1 : (apl.count > 5 ? 1 : 0));
+            var calcAPL = apl.count > 0 ? Math.round(apl.levels / apl.count) : 0;
 
             //get the monster xp
             let combatxp = 0;
@@ -48,6 +46,11 @@ export class AssignXPApp extends Application {
                         combatxp += (MonksTokenBar.system.getXP(combatant.actor)?.value || 0);
                 }
             };
+
+            // For Pathfinder 2e, if the party is bigger or smaller than 4, then we need to adjust the XP reward
+            if (game.system.id == 'pf2e')
+                combatxp = Math.floor(combatxp * 4 / (apl.count || 4));
+
             //xp += (combatant?.actor.system.details?.xp?.value || MonksLittleDetails.xpchart[Math.clamped(parseInt(combatant?.actor.system.details?.level?.value), 0, MonksLittleDetails.xpchart.length - 1)] || 0);
             this.xp = this.xp || combatxp;
             this.reason = this.reason || i18n("MonksTokenBar.CombatExperience");

--- a/systems/base-rolls.js
+++ b/systems/base-rolls.js
@@ -51,7 +51,7 @@ export class BaseRolls {
     }
 
     getLevel(actor) {
-        return actor.system.details?.level?.value || actor.system.details?.level || 0;
+        return actor.system.details?.level?.value ?? actor.system.details?.level ?? 0;
     }
 
     get dcLabel() {

--- a/systems/pf2e-rolls.js
+++ b/systems/pf2e-rolls.js
@@ -121,7 +121,8 @@ export class PF2eRolls extends BaseRolls {
             }
         };
 
-        return combatxp;
+        // If the party is larger or smaller than four PCs, adjust the XP reward to account for it
+        return Math.floor(combatxp * 4 / (apl.count || 4));
     }
 
     get useDegrees() {


### PR DESCRIPTION
### Fix Pathfinder 2e XP Calculation (Fixes #251)
In Pathfinder 2e, if the party is of a non-standard size (i.e. not four) then the guidelines are to adjust the encounter to add more "XP" but not award that extra XP to the party. In effect, the encounter's XP reward is divided amongst the party.

For example, a group of four level 1 PCs facing two level 1 NPCs is a "moderate" encounter, worth 80 XP, and each player would be rewarded 80 XP. However, a moderate encounter for six level 1 PCs requires an XP budget of 120 XP, but the players are still only rewarded 80 XP. The effective formula is to sum the XP values of the NPCs (based on the party level), multiply it by four, and _then_ divide by the number of PCs.

I've updated the Assign XP function to do this. We no longer consider the party to be of a higher or lower level if there are more or fewer members. This results in XP rewards being consistent with the "XP" macro found in the Pathfinder 2e system.

### Fix 0-Level Actors
In addition, I've corrected `baseRolls.js` to only fall back on other methods of finding the actor's level when the value is `undefined` or `null`, not simply a falsey. Zero is a valid actor level in Pathfinder 2e, and the existing function resulted in `NaN` being returned for zero-level actors.