### PR TITLE
Fix Perception reference for pf2e roll request

### DIFF
--- a/systems/pf2e-rolls.js
+++ b/systems/pf2e-rolls.js
@@ -157,7 +157,8 @@ export class PF2eRolls extends BaseRolls {
         };
 
         if (request.type == 'attribute') {
-            rollfn = actor.system.attributes[request.key].roll;
+            rollfn = actor[request.key].check.roll;
+            actor = actor[request.key].check
             opts.options = ["ignore"];
         }
         else if (request.type == 'save') {


### PR DESCRIPTION
Made attribute checks parallel to save and skill checks, which is necessary for v11

Closes #379 