### PR TITLE
Fix an error when the stats is not an array #394

### DIFF
--- a/apps/editstats.js
+++ b/apps/editstats.js
@@ -5,9 +5,12 @@ export class EditStats extends FormApplication {
     constructor(object, options = {}) {
         let stats = object?.getFlag('monks-tokenbar', 'stats') || MonksTokenBar.stats;
         options.height = 62 + (Math.max(stats.length, 4) * 27);
-
+        
         super(object, options);
-        this.stats = (stats || []).map(s => {
+        if (!Array.isArray(stats)) {
+            stats = []; // If the stats is not an array, construct an empty array instead.
+        }
+        this.stats = stats.map(s => {
             s.id = s.id || makeid();
             return s;
         });


### PR DESCRIPTION
[#394](https://github.com/ironmonk88/monks-tokenbar/issues/394#issue-1819741869)

I seem to have found the cause of the problem. 
An unknown conflict mod sets the stats to blank and can not be recovered. And can not be undone by resetting settings.
```
Uncaught TypeError: (stats || []).map is not a function
at new EditStats (editstats.js:10:36)
at ExtendedSettingsConfig._onClickSubmenu (foundry.js:82272:17)
at HTMLButtonElement.dispatch (jquery.min.js:2:43184)
at y.handle (jquery.min.js:2:41168) 
```

Using the latest version still encountered errors, I tried to modify the code with my own understanding, and maybe resolved.
The original code is
```
// https://github.com/ironmonk88/monks-tokenbar/blob/ad5ce359ab489f46adb9596d7ff667c8b56d187f/apps/editstats.js#L10C1-L10C1
this.stats = (stats || []).map(s => {
s.id = s.id || makeid();
return s;
}); 
```
The broken stats may not be an array, so an error occurred.
So I changed the code to
```
        if (!Array.isArray(stats)) {
            stats = []; 
        }
       // If the stats is not an array, construct an empty array instead.
        this.stats = stats.map(s => {
            s.id = s.id || makeid();
            return s;
        });
```
Thus, I solved the problem, and although I needed to manually add the stats that were purged due to corruption.
![image](https://github.com/ironmonk88/monks-tokenbar/assets/73411104/6788bbe2-19d5-48ab-85fa-eb1e05b7e13a)
For me, it works fine now.


