### PR TITLE
SWADE case-sensitive compare in skill name error

### DIFF
--- a/systems/swade-rolls.js
+++ b/systems/swade-rolls.js
@@ -101,7 +101,7 @@ export class SwadeRolls extends BaseRolls {
             rollfn = actor.rollAttribute;
         }
         else if (request.type == 'skill') {
-            let item = actor.items.find(i => i.name == request.key && i.type == 'skill');
+            let item = actor.items.find(i => MonksTokenBar.slugify(i.name) == request.key && i.type == 'skill');
             sysRequest = item.id;
             rollfn = actor.rollSkill;
         } else {


### PR DESCRIPTION
Skill name was being compared to key, but key was created with slugify and there was a case mismatch preventing skill rolls from working.