### PR TITLE
Make flags available for stats

### DIFF
--- a/apps/tokenbar.js
+++ b/apps/tokenbar.js
@@ -401,7 +401,11 @@ export class TokenBar extends Application {
         let defaultColor = $('#tokenbar .token .token-stat').css('color') || '#f0f0f0';
 
         for (let stat of viewstats) {
-            let value = TokenBar.processStat(stat.stat, entry.actor.system) || TokenBar.processStat(stat.stat, entry.token);
+            const data = {
+                ...entry.actor.system,
+                flags: { ...entry.actor.flags }
+            }
+            let value = TokenBar.processStat(stat.stat, data) || TokenBar.processStat(stat.stat, entry.token);
 
             if (entry.stats[stat.stat] == undefined) {
                 entry.stats[stat.stat] = { icon: stat.icon, color: stat.color || defaultColor, value: value, hidden: (!setting("show-undefined") && value == undefined) };


### PR DESCRIPTION
Allows the use of flags in the token bar's stats:
![monks-token-bar-flags](https://github.com/ironmonk88/monks-tokenbar/assets/105953297/b056af25-5bbc-40cd-9c17-09a54c87e2d1)
