### PR TITLE
Fix PF2e 6.1.0+ update compatibility

### DIFF
--- a/module.json
+++ b/module.json
@@ -1,7 +1,7 @@
 {
   "title": "Monk's TokenBar",
   "description": "Add a bar with all the current player tokens.  Limit movement, roll saving throws, assign XP.",
-  "version": "12.01",
+  "version": "12.02",
   "authors": [
     {
       "name": "IronMonk",
@@ -82,7 +82,7 @@
     "css/tokenbar.css"
   ],
   "url": "https://github.com/ironmonk88/monks-tokenbar",
-  "download": "https://github.com/ironmonk88/monks-tokenbar/archive/12.01.zip",
+  "download": "https://github.com/ironmonk88/monks-tokenbar/archive/12.02.zip",
   "manifest": "https://github.com/ironmonk88/monks-tokenbar/releases/latest/download/module.json",
   "bugs": "https://github.com/ironmonk88/monks-tokenbar/issues",
   "allowBugReporter": true,

--- a/systems/pf2e-rolls.js
+++ b/systems/pf2e-rolls.js
@@ -5,7 +5,7 @@ export class PF2eRolls extends BaseRolls {
     constructor() {
         super();
 
-        const { lore, ...skills } = this.config.skillList
+        const { lore, ...skills } = this.config.skills
 
         this._requestoptions = [
             { id: "attribute", text: i18n("MonksTokenBar.Attribute"), groups: { perception: i18n("PF2E.PerceptionLabel") } },


### PR DESCRIPTION
Seems like pf2e has changed the skill list from "skillList" to "skills"

I manually tested this and this one change seems to have helped on first glance