### PR TITLE
Add looking for possible attributes on contested rolls

### DIFF
--- a/apps/contestedroll.js
+++ b/apps/contestedroll.js
@@ -50,10 +50,32 @@ export class ContestedRollApp extends Application {
     }
 
     getData(options) {
+        let dispOptions = this.requestoptions;
+        try {
+            if (this.entries.length > 0) {
+                let dynamic = MonksTokenBar.system.dynamicRequest(this.entries);
+
+                if (dynamic) {
+                    let dispDyn = dynamic.map(de => {
+                        return Object.assign({}, de, { groups: Object.entries(de.groups).reduce((a, [k, v]) => ({ ...a, [k]: v.label || v }), {}) });
+                    });
+
+                    dispOptions = [...this.requestoptions, ...dispDyn];
+                    this.requestoptions = this.requestoptions.concat(dynamic);
+                }
+            }
+        } catch {}
+
+        let entries = this.entries.map(e => {
+            let img = e.token?.document?.texture?.src || e.token?.img;
+
+            return foundry.utils.mergeObject({ img }, e);
+        });
+
         return {
-            entries: this.entries,
+            entries: entries,
             rollmode: this.rollmode,
-            options: this.requestoptions,
+            options: dispOptions,
             hidenpcname: this.hidenpcname,
             flavor: this.flavor,
         };


### PR DESCRIPTION
Hi. Hope i find you well @ironmonk88!

There are some issues with contestedrolls having much less options then savingthrows. Fixed it for my fork, as i need it for my campaign. It ain't the best fix as i just throw logic from savingthrows to contestedrolls and ignored logic if there less then 2 actors chosen, but it works alright at least :)

Example issues
[#484](https://github.com/ironmonk88/monks-tokenbar/issues/484)