### PR TITLE
Add optional chaining to fix an error when item actor is undefined

### DIFF
--- a/apps/tokenbar.js
+++ b/apps/tokenbar.js
@@ -36,7 +36,7 @@ export class TokenBar extends Application {
 
         Hooks.on('updateItem', (item, data, options) => {
             if (((game.user.isGM || setting("allow-player")) && !setting("disable-tokenbar"))) {
-                let entry = this.entries.find(t => t.actor?.id == item.actor.id);
+                let entry = this.entries.find(t => t.actor?.id == item?.actor?.id);
                 if (entry != undefined) {
                     this.updateEntry(entry);
                 }
@@ -82,7 +82,7 @@ export class TokenBar extends Application {
             if (((game.user.isGM || setting("allow-player")) && !setting("disable-tokenbar"))) {
                 if (item.type == 'effect') {
                     if (item.actor) {
-                        let entry = this.entries.find(t => t.actor?.id == item.actor.id);
+                        let entry = this.entries.find(t => t.actor?.id == item?.actor?.id);
                         if (entry != undefined) {
                             this.updateEntry(entry)
                         }
@@ -94,7 +94,7 @@ export class TokenBar extends Application {
         Hooks.on("deleteItem", (item) => {
             if (((game.user.isGM || setting("allow-player")) && !setting("disable-tokenbar"))) {
                 if (item.type == 'effect') {
-                    let entry = this.entries.find(t => t.actor?.id == item.actor.id);
+                    let entry = this.entries.find(t => t.actor?.id == item?.actor?.id);
                     if (entry != undefined) {
                         this.updateEntry(entry)
                     }


### PR DESCRIPTION
Hey @ironmonk88, thank you for this amazing module!

When writing a macro, I've noticed I had this error when updating an item that is not attached to an actor:
```
foundry.js:655 Error: Error thrown in hooked function '' for hook 'updateItem'. Cannot read properties of null (reading 'id')
[Detected 1 package: monks-tokenbar(12.04)]
    at Hooks.onError (foundry.js:654:24)
    at 🎁Hooks.onError#0 (libWrapper-wrapper.js:188:54)
    at #call (foundry.js:636:36)
    at Hooks.callAll (foundry.js:589:17)
    at foundry-esm.js:56584:17
    at foundry-esm.js:56590:43
    at Array.map (<anonymous>)
    at #handleUpdateDocuments (foundry-esm.js:56590:33)
    [...]
Caused by: TypeError: Cannot read properties of null (reading 'id')
[Detected 1 package: monks-tokenbar(12.04)]
    at tokenbar.js:39:78
    at Array.find (<anonymous>)
    at Object.fn (tokenbar.js:39:42)
    at #call (foundry.js:632:20)
    at Hooks.callAll (foundry.js:589:17)
    at foundry-esm.js:56584:17
    at foundry-esm.js:56590:43
    at Array.map (<anonymous>)
    at #handleUpdateDocuments (foundry-esm.js:56590:33)
    [...]
```

After a quick investigation, it appears the error comes from this function: 
```javascript
Hooks.on('updateItem', (item, data, options) => {
    if (((game.user.isGM || setting("allow-player")) && !setting("disable-tokenbar"))) {
        let entry = this.entries.find(t => t.actor?.id == item.actor.id);
        if (entry != undefined) {
            this.updateEntry(entry);
        }
    }
});
```

When using the dev tool debugging watch, I've observed that `item.actor` is `undefined`. I assume this is because the item is not attached to an actor yet. So I've added some optional chaining (`?`) to prevent this issue from occurring. Technically, it's not required to do that on `item` too, but in my opinion, it's better to be safe than sorry. Same with similar objects.